### PR TITLE
get order and attachment apis

### DIFF
--- a/openhack-Api/api/order.js
+++ b/openhack-Api/api/order.js
@@ -1,0 +1,122 @@
+const db_utlity = require("../db-utility");
+const db_constants = require("../constants");
+
+/** Add attachment to the existing order */
+exports.addAttachement = (req, res) => {
+    /**@param: documentId, documentRev, attachmentName (PaymentReceipt/SupplierFinalBill), 
+     * data - attachement content/data as base64 string, contentType
+     *  under req.body */
+
+    /**
+     {
+       "documentId":"09111924cd6492d8cd7783138a716b7b",
+       "documentRev":"8-a95060b5ad279877358035b9281d0e21",
+       "attachmentName":"PaymentReceipt",
+       "data":"md5-uZ4eaHUG7BBW8gAjVCD0CA==",
+       "contentType":"image/png"
+       }
+     */
+
+    let attachment = {
+        documentId: req.body.documentId, documentRev: req.body.documentRev,
+        Name: req.body.attachmentName, data: req.body.data, contentType: req.body.contentType
+    };
+
+    // Mock
+    // attachment = {
+    //     documentId: "09111924cd6492d8cd7783138a716b7b", documentRev: "5-e09fbf01ed3b855479b66e8e6bebe8f5",
+    //     Name: "PaymentReceipt", data: "md5-uZ4eaHUG7BBW8gAjVCD0CA==", contentType: "image/png"
+    // };
+
+    if (attachment.documentId && attachment.Name && attachment.data && attachment.contentType) {
+        let db = db_utlity.getDbInstance(db_constants["ORDERS"]);
+        db.attachment.insert(attachment.documentId, attachment.Name, attachment.data, attachment.contentType,
+            { rev: attachment.documentRev }).then((body) => {
+                res.json(body);
+            }).catch((err) => {
+                console.log(err);
+                res.json("Database error!");
+            });
+    }
+    else {
+        res.json("Required parameters are missing in the request!")
+    }
+};
+
+exports.getAttachment = (req, res) => {
+    /**@param: residentId (required), supplierId - optional, status -optional under the req.body */
+    /**
+    {
+        "documentId":"09111924cd6492d8cd7783138a716b7b",
+        "attachmentName":"PaymentReceipt"
+    }
+     */
+
+    let documentId = req.body.documentId;
+    let attachmentName = req.body.attachmentName;
+
+    // // Mock
+    // documentId = "09111924cd6492d8cd7783138a716b7b";
+    // attachmentName = "PaymentReceipt";
+
+    if (documentId && attachmentName) {
+        let db = db_utlity.getDbInstance(db_constants["ORDERS"]);
+
+        db.attachment.get(documentId, attachmentName).then((body) => {
+            res.json(body.toString('base64'));
+        }).catch((err) => {
+            console.log(err);
+            res.json("Attachment not found!");
+        });
+    }
+    else {
+        res.json("Required parameters are missing in the request!");
+    }
+};
+
+/**
+  * Fetch order by resident id
+ */
+exports.getOrders = (req, res) => {
+    /**@param: residentId or supplierId at least one, status -optional under the req.body */
+    /** 
+    {
+        "residentId":"11e256395e9a14982b01cd1d5b24849d",
+        "supplierId":""
+      }
+    */
+
+    let residentId = req.body.residentId;
+    let supplierId = req.body.supplierId;
+    let status = req.body.status;
+    let selector = {};
+
+    // Mock 
+    // residentId = "11e256395e9a14982b01cd1d5b24849d";
+
+    if (residentId || supplierId) {
+        let db = db_utlity.getDbInstance(db_constants["ORDERS"]);
+
+        selector['residentId'] = residentId;
+        selector['supplierId'] = supplierId;
+
+        if (status) {
+            selector['status'] = status;
+        }
+
+        db.find({
+            'selector': selector
+        }, (err, documents) => {
+            if (err) {
+                res.json(err);
+
+            } else {
+                res.json(documents.docs);
+            }
+        });
+    }
+    else {
+        res.json("Required parameters are missing in the request!");
+    }
+};
+

--- a/openhack-Api/app.js
+++ b/openhack-Api/app.js
@@ -13,6 +13,7 @@ dotenv.config({ path: 'developmet.env' });
 const apiRoutes = require('./api');
 const apiUserRoutes = require('./api/user');
 const apiCommunityRoutes = require('./api/community');
+const apiOrderRoutes = require('./api/order');
 
 /**
  * Create Express server.
@@ -28,6 +29,7 @@ app.use(bodyParser.json());
 /**
  * Api routes.
  */
+
 app.get('/api', apiRoutes.index);
 app.post('/api/user/getAllUsers',apiUserRoutes.GetAllUsers);
 app.post('/api/user/findUserByEmail',apiUserRoutes.FindUserbyEmailId);
@@ -36,6 +38,10 @@ app.post('/api/user/deleteRejectedUser',apiUserRoutes.DeleteRejectedUser);
 app.post('/api/user/registerUser',apiUserRoutes.RegisterUser);
 app.post('/api/community/filterCommunityBySearchTerm',apiCommunityRoutes.FilterBySearchTerm);
 app.post('/api/community/registerCommunity',apiCommunityRoutes.RegisterCommunity);
+app.post('/api/order/getOrders', apiOrderRoutes.getOrders);
+app.post('/api/order/addAttachment', apiOrderRoutes.addAttachement);
+app.post('/api/order/getAttachment', apiOrderRoutes.getAttachment);
+
 app.get('*', apiRoutes.index);
 /**
  * Error Handler.

--- a/openhack-Api/constants.js
+++ b/openhack-Api/constants.js
@@ -1,6 +1,7 @@
 const Databases = {
     "COMMUNITY": "community",
-    "RESIDENTDB-USERS": "residentsdb-users"
+    "RESIDENTDB-USERS": "residentsdb-users",
+    "ORDERS":"orders"
 }
 
 module.exports = Databases;


### PR DESCRIPTION
Added api methods to get order, add attahment, get attachent.

api/order/getOrders:
    {
        "residentId":"11e256395e9a14982b01cd1d5b24849d",
        "supplierId":""
      }

api/order/addAttachement:
    {
       "documentId":"09111924cd6492d8cd7783138a716b7b",
       "documentRev":"8-a95060b5ad279877358035b9281d0e21",
       "attachmentName":"PaymentReceipt",
       "data":"md5-uZ4eaHUG7BBW8gAjVCD0CA==",
       "contentType":"image/png"
       }

api/order/getAttachment:
    {
        "documentId":"09111924cd6492d8cd7783138a716b7b",
        "attachmentName":"PaymentReceipt"
    }
