### PR TITLE
Added node api url from IBM cloud

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -22,6 +22,7 @@ export class ApiRoutes {
 
 function getLocalDomain(){
     return "http://localhost:8080/";
+    //return "http://digicomm-api.eu-gb.cf.appdomain.cloud/";
 }
 
 export class OrderStatus {


### PR DESCRIPTION
If you want to access the node api hosted in IBM cloud, just uncomment the statement: `return "http://digicomm-api.eu-gb.cf.appdomain.cloud/";` and you access the api from cloud.